### PR TITLE
docs: record v0.4.1 publication metrics

### DIFF
--- a/docs/project-metrics.md
+++ b/docs/project-metrics.md
@@ -2,25 +2,29 @@
 
 This file is an auditable snapshot from the public GitHub API. Update it from observable repository and release data; do not estimate or inflate values.
 
-**Metrics timestamp (UTC):** 2026-09-07T00:53:36.5456407Z
+**Metrics timestamp (UTC):** 2026-09-09T10:29:55.9688185Z
 
 **Repository:** https://github.com/yel66026-stack/xiaoye-radar
 
-| Metric                             | Current value |
-| ---------------------------------- | ------------: |
-| GitHub Stars                       |             0 |
-| Forks                              |             0 |
-| Maintainers in Git log             |             1 |
-| External human contributors        |             0 |
-| Open Issues                        |             0 |
-| Closed Issues                      |             0 |
-| Open pull requests                 |             5 |
-| Closed pull requests               |             0 |
-| Open Dependabot pull requests      |             5 |
-| Open human/community pull requests |             0 |
-| Published Releases                 |             1 |
-| Windows EXE downloads              |             2 |
-| SHA-256 asset downloads            |             2 |
-| External Adapters                  |             0 |
+| Metric                              | Current value |
+| ----------------------------------- | ------------: |
+| GitHub Stars                        |            32 |
+| Forks                               |             1 |
+| Maintainers in Git log              |             1 |
+| External human contributors         |             0 |
+| Open Issues                         |             0 |
+| Closed Issues                       |             0 |
+| Open pull requests                  |             4 |
+| Closed pull requests                |             2 |
+| Open Dependabot pull requests       |             4 |
+| Closed Dependabot pull requests     |             1 |
+| Open human/community pull requests  |             0 |
+| Merged human-authored pull requests |             1 |
+| Published Releases                  |             2 |
+| `v0.4.0` Windows EXE downloads      |             2 |
+| `v0.4.0` SHA-256 asset downloads    |             2 |
+| `v0.4.1` Windows EXE downloads      |             0 |
+| `v0.4.1` SHA-256 asset downloads    |             0 |
+| External Adapters                   |             0 |
 
-The five open pull requests were created automatically by GitHub Dependabot from the committed dependency-update configuration; they are not community contributions. There are no human/community pull requests or external human contributors in this snapshot. Release asset counts were read after the required anonymous public-download verification; source archive downloads are not included.
+The four open pull requests were created automatically by GitHub Dependabot from the committed dependency-update configuration; they are not community contributions. Pull request #5 was closed automatically after its dependency landed through the maintenance branch. Pull request #6 is the merged, owner-authored `v0.4.1` maintenance release and is not an external contribution. There are no open human/community pull requests or external human contributors in this snapshot. Release asset counts are the values returned by the GitHub API after publication; source archive downloads are not included.


### PR DESCRIPTION
## Summary

- Records the post-publication GitHub API snapshot for `v0.4.1`.
- Separates `v0.4.0` and `v0.4.1` EXE/checksum download counters.
- Records 32 stars, 1 fork, 0 issues, 4 open Dependabot PRs, 1 merged owner-authored maintenance PR, and 2 published releases without treating owner or bot activity as external contribution.

## Verification

- Values were read from the live repository, Issues, Pull Requests, contributors, and Release APIs at `2026-09-09T10:29:55.9688185Z`.
- `npx prettier --check docs/project-metrics.md`
- `git diff --check`

This documentation-only PR does not change the `v0.4.1` tag or release assets.